### PR TITLE
Update supported Laravel versions in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.0|^7.4",
-        "laravel/framework": "^6.0|^7.0|^8.0|^9.0|^10.0",
+        "laravel/framework": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
         "spatie/array-to-xml": "^3.1",
         "guzzlehttp/guzzle": "^6.3.1|^7.0.1"
     },


### PR DESCRIPTION
Added support for Laravel framework versions 11 and 12 in the composer.json file. This ensures compatibility with the latest Laravel releases while maintaining support for older versions.